### PR TITLE
added support for arm64 to Class_GetMethodImplementationStret

### DIFF
--- a/objc/base.m
+++ b/objc/base.m
@@ -72,7 +72,11 @@ void* Class_GetMethodImplementation(void* cls, void* sel) {
 }
 
 void* Class_GetMethodImplementationStret(void* cls, void* sel) {
+#ifndef __arm64__
     return class_getMethodImplementation_stret((Class)cls, (SEL)sel);
+#else
+    return class_getMethodImplementation((Class)cls, (SEL)sel);
+#endif
 }
 
 void* Class_GetInstanceMethod(void* cls, void* sel) {


### PR DESCRIPTION
class_getMethodImplementation_stret is not defined on arm64 so this PR adds a arch check and replace the call to class_getMethodImplementation_stret with one to class_getMethodImplementation on Apple Silicon.